### PR TITLE
feat: allow usage of async/await in custom JS templates

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -165,7 +165,7 @@ export class Template implements ITemplate {
                 page: context.block.page,
                 level: lvl,
             })
-            return renderrer.renderString(b.content, renderContext)
+            return renderrer.renderStringAsync(b.content, renderContext)
         })
     }
     getArgProperties() {
@@ -209,7 +209,7 @@ export class InlineTemplate implements ITemplate {
         const renderrer = RenderingSyntax.latest()
         const body = '`` ' + this.body + ' ``'
         return {
-            content: renderrer.renderString(body, renderContext),
+            content: await renderrer.renderStringAsync(body, renderContext),
             children: [],
         }
     }


### PR DESCRIPTION
Hi, first, thanks for this great plugin 🙏.

I am trying to use the custom JS templates to access logseq API, which is mostly async.
This PR adds support for async/await to the custom JS templates (\`\`{}\`\`).
Other types of templates are not supported as they use `eval` to evaluate the passed code.